### PR TITLE
Prohibit following redirects whilst fetching Client Metadata

### DIFF
--- a/draft-ietf-oauth-client-id-metadata-document.md
+++ b/draft-ietf-oauth-client-id-metadata-document.md
@@ -167,7 +167,7 @@ inform their security policies.
 
 ## Client Metadata Document
 
-A Client Metadata Document is a JSON document {{RFC8259}} containing the client
+A Client Metadata Document is a JSON document as described in {{Section 4 of RFC8259}} containing the client
 registration information for the client. The properties of the Client Metadata
 Document are the values defined in the OAuth Dynamic Client Registration
 Metadata OAuth Parameters registry


### PR DESCRIPTION
This addresses the concerns raised in #44 and by Dick Hardt on the mailing list. Following redirects would likely give you a final document URI that is not equal to the supplied `client_id`, and as such should not be trusted.

We could potentially limit this further to only accepting 200 OK responses.