### PR TITLE
Restrict URI properties to absolute URIs using the https: scheme

### DIFF
--- a/draft-parecki-oauth-client-id-metadata-document.md
+++ b/draft-parecki-oauth-client-id-metadata-document.md
@@ -176,6 +176,8 @@ client metadata document:
 `client_secret_basic`, `client_secret_jwt`, or any other method based around
 a shared symmetric secret.
 * the `client_secret` and `client_secret_expires_at` properties MUST NOT be used
+* the properties that refer to URIs, such as `client_uri` and `logo_uri`, MUST be absolute URIs
+using the `https:` scheme, with the exception of the `redirect_uris` which MAY use custom schemes.
 
 See {{client_authentication}} for more details.
 


### PR DESCRIPTION
This was originally noted in #18 and #19 and changed in #33, however prohibiting just `data:` and `javascript:` would not be a sufficient security measure, as there are other URI schemes that are unsafe, such as `vbscript:` and `shortcuts:` (apple shortcuts).

Interestingly, I know `vbscript:` exists, however, it is not registered with IANA: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml