### PR TITLE
Clarify requirements for Client ID Metadata Document Services

### DIFF
--- a/draft-ietf-oauth-client-id-metadata-document.md
+++ b/draft-ietf-oauth-client-id-metadata-document.md
@@ -197,6 +197,13 @@ To enable developers to author applications on their machines, without exposing 
 A Client ID Metadata Document Service is a web service through which developers can acquire a stable URL to a Client ID Metadata Document. This service MAY expire clients from time to time, and MAY require developers to provide additional information about the client being developed.
 
 
+The only requirement on Client ID Metadata Document Services is that they MUST
+return valid Client ID Metadata Documents for the `client_id`s that they
+provision, or return a status code indicating an error response (e.g., 404 Not
+Found). How a Client ID Metadata Document Service creates or stores metadata
+documents is outside of the scope of this document.
+
+
 By providing at least one Client ID Metadata Document Service, an authorization server can enable developers to create applications, and still indicate to non-technical people that the client that they are about to authorize is currently under-development and may not be trustworthy or secure.
 
 ## Metadata Discovery Errors


### PR DESCRIPTION
The way in which a Client ID Metadata Document Service works is up to the implementer of that service, the only requirement is that they return valid Client ID Metadata Documents for the `client_id` URIs that they provision, or return an appropriate status code for an error response.

I do have a reference implementation of a Client ID Metadata Document Service which is open to the general public, but enforces the additional restrictions that Bluesky's AT Protocol has for Client ID Metadata Documents, which can be found at https://cimd-service.fly.dev — however, I want to be clear that that API isn't a standard API.