### PR TITLE
Clarify loopback exception for SSRF checks

### DIFF
--- a/draft-ietf-oauth-client-id-metadata-document.md
+++ b/draft-ietf-oauth-client-id-metadata-document.md
@@ -304,9 +304,9 @@ If fetching the client metadata document fails for any reason, the `client_id` U
 
 ## Server Side Request Forgery (SSRF) Attacks {#ssrf_attacks}
 
-Authorization servers fetching the client metadata document and resolving URLs located in the metadata document should be aware of possible SSRF attacks. Authorization servers MUST validate that the Client ID Metadata Document URL does not resolve to special-use IP addresses as defined in {{RFC6890}}, except when the authorization server itself is also running on a loopback address and the resolved address matches the same loopback interface.
+Authorization servers fetching the client metadata document and resolving URLs contained within it should be aware of possible SSRF attacks. Authorization servers MUST NOT fetch a Client ID Metadata Document URL or any URLs contained within a Client ID Metadata Document that resolve to special-use IP addresses as defined in {{RFC6890}}, except when the authorization server itself is running on a loopback address and the resolved address matches the same loopback interface.
 
-Authorization servers SHOULD NOT fetch any URLs contained within Client ID Metadata Documents that resolve to special-use IP addresses as defined in {{RFC6890}} and consider network policies or other measures to prevent making requests to these addresses. Authorization servers which support non-http-based URI schemes are at additional risk of SSRF attacks.
+Authorization servers SHOULD consider network policies or other measures to prevent making requests to special-use addresses. Authorization servers which support non-http-based URI schemes are at additional risk of SSRF attacks.
 
 
 ## Maximum Response Size for Client Metadata Documents


### PR DESCRIPTION
This clarifies that SSRF checks for both the CIMD itself and URLs within it should be handled the same way: don't fetch special use IPs unless everything is running on loopback. 

This change does normatively strengthen the requirements for URLs within the CIMD. My assumption is that the current wording of MUST NOT for the CIMD itself with an exception for running on loopback and SHOULD NOT for contained URLs is meant to accomplish the same thing, and I thought combining the two made it read more clearly.

See also #73. 