### PR TITLE
Update OpenID Federation version and date

### DIFF
--- a/draft-ietf-oauth-client-id-metadata-document.md
+++ b/draft-ietf-oauth-client-id-metadata-document.md
@@ -73,9 +73,9 @@ informative:
       - name: C. Mortimore
         org: Disney
   OpenID.Federation:
-    title: "OpenID Federation 1.0"
-    date: 2024-05-17
-    target: https://openid.net/specs/openid-federation-1_0.html
+    title: "OpenID Federation 1.1"
+    date: 2024-05-05
+    target: https://openid.net/specs/openid-federation-1_1.html
     author:
       - name: R. Hedberg
         org: independent

--- a/draft-ietf-oauth-client-id-metadata-document.md
+++ b/draft-ietf-oauth-client-id-metadata-document.md
@@ -75,7 +75,7 @@ informative:
   OpenID.Federation:
     title: "OpenID Federation 1.1"
     date: 2026-05-05
-    target: https://openid.net/specs/openid-federation-1_1.html
+    target: https://openid.net/specs/openid-federation-1_1-final.html
     author:
       - name: R. Hedberg
         org: independent

--- a/draft-ietf-oauth-client-id-metadata-document.md
+++ b/draft-ietf-oauth-client-id-metadata-document.md
@@ -74,7 +74,7 @@ informative:
         org: Disney
   OpenID.Federation:
     title: "OpenID Federation 1.1"
-    date: 2024-05-05
+    date: 2026-05-05
     target: https://openid.net/specs/openid-federation-1_1.html
     author:
       - name: R. Hedberg


### PR DESCRIPTION
Alternatively, it can point to [OpenID Federation for OpenID Connect 1.1](https://openid.net/specs/openid-federation-connect-1_1-final.html).